### PR TITLE
SLING-8419 JSON serializer for configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,10 +62,10 @@
                         <Conditional-Package>
                             org.apache.felix.configurator.impl.json,
                             org.apache.felix.configurator.impl.model,
-                            org.apache.sling.feature,
-                            org.apache.sling.feature.*
+                            org.apache.sling.feature.io,
                         </Conditional-Package>
                         <Embed-Dependency>
+                            org.apache.sling.commons.johnzon,
                             org.apache.felix.converter,
                             org.apache.felix.configadmin;inline="org/apache/felix/cm/file/ConfigurationHandler.*",
                             org.apache.sling.commons.osgi;inline="org/apache/sling/commons/osgi/ManifestHeader*.*|org/apache/sling/commons/osgi/PropertiesUtil.*|org/apache/sling/commons/osgi/SortingServiceTracker.*"
@@ -138,7 +138,7 @@
                         <exclude>src/test/resources/**</exclude>
                     </excludes>
                 </configuration>
-             </plugin>
+            </plugin>
         </plugins>
     </build>
 
@@ -170,7 +170,7 @@
             <version>1.8.12</version>
             <scope>provided</scope>
         </dependency>
-        <!-- We use classes from the configurator, json api and converter to read JSON config files -->
+        <!-- We use classes from the configurator, json api, converter and feature.io to read/write JSON config files -->
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.configurator</artifactId>
@@ -189,24 +189,17 @@
             <version>1.1.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
-        <!-- transitive dependency of feature.io -->
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.feature</artifactId>
-            <version>1.1.0</version>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.utils</artifactId>
             <version>1.11.2</version>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.geronimo.specs</groupId>
-            <artifactId>geronimo-json_1.0_spec</artifactId>
-            <version>1.0-alpha-1</version>
-            <scope>provided</scope>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.johnzon</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
         </dependency>
         <!-- Basic dependencies for Unit Tests -->
         <dependency>
@@ -233,12 +226,6 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.6</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.johnzon</groupId>
-            <artifactId>johnzon-core</artifactId>
-            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,30 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
+    or more contributor license agreements. See the NOTICE file
     distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
+    regarding copyright ownership. The ASF licenses this file
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
-    
+    with the License. You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
+    KIND, either express or implied. See the License for the
     specific language governing permissions and limitations
     under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling</artifactId>
         <version>30</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <artifactId>org.apache.sling.installer.core</artifactId>
@@ -37,30 +38,35 @@
         by supplying input streams and dictionaries.
     </description>
 
+    <properties>
+        <sling.java.version>8</sling.java.version>
+    </properties>
     <scm>
         <connection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-installer-core.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-installer-core.git</developerConnection>
         <url>https://gitbox.apache.org/repos/asf?p=sling-org-apache-sling-installer-core.git</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<extensions>true</extensions>
-				<configuration>
-					<instructions>
-						<Bundle-Activator>
-							org.apache.sling.installer.core.impl.Activator
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-Activator>
+                            org.apache.sling.installer.core.impl.Activator
                         </Bundle-Activator>
                         <Conditional-Package>
                             org.apache.felix.configurator.impl.json,
-                            org.apache.felix.configurator.impl.model                            
+                            org.apache.felix.configurator.impl.model,
+                            org.apache.sling.feature,
+                            org.apache.sling.feature.*
                         </Conditional-Package>
                         <Embed-Dependency>
-                            geronimo-json_1.0_spec,johnzon-core,org.apache.felix.converter,
+                            org.apache.felix.converter,
                             org.apache.felix.configadmin;inline="org/apache/felix/cm/file/ConfigurationHandler.*",
                             org.apache.sling.commons.osgi;inline="org/apache/sling/commons/osgi/ManifestHeader*.*|org/apache/sling/commons/osgi/PropertiesUtil.*|org/apache/sling/commons/osgi/SortingServiceTracker.*"
                         </Embed-Dependency>
@@ -68,32 +74,32 @@
                             osgi.service;objectClass:List<String>="org.apache.sling.installer.api.OsgiInstaller,org.apache.sling.installer.api.ResourceChangeListener,org.apache.sling.installer.api.info.InfoProvider,org.apache.sling.installer.api.tasks.RetryHandler",
                             osgi.service;objectClass:List<String>="org.apache.sling.installer.api.event.InstallationListener,org.apache.sling.installer.api.jmx.InstallerMBean"
                         ]]></Provide-Capability>
-					</instructions>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<systemProperties>
-						<property>
-							<name>osgi.installer.base.dir</name>
-							<value>${project.build.directory}</value>
-						</property>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <property>
+                            <name>osgi.installer.base.dir</name>
+                            <value>${project.build.directory}</value>
+                        </property>
                         <property>
                             <name>osgi.installer.pom.version</name>
                             <value>${project.version}</value>
                         </property>
-					</systemProperties>
-				</configuration>
-			</plugin>
-			<plugin>
-				<!-- Create dummy test bundles -->
-				<artifactId>maven-antrun-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>testbundle-1.0</id>
-						<phase>compile</phase>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+            <plugin>
+                <!-- Create dummy test bundles -->
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>testbundle-1.0</id>
+                        <phase>compile</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>
@@ -101,20 +107,20 @@
                             <tasks name="Create a test bundle">
                                 <jar destfile="${project.build.directory}/${project.artifactId}-${project.version}-testbundle-1.0.jar">
                                     <fileset dir="${project.build.directory}/classes">
-                                        <include name="META-INF/**" />
+                                        <include name="META-INF/**"/>
                                     </fileset>
                                     <manifest>
-                                        <attribute name="Manifest-Version" value="2" />
-                                        <attribute name="Bundle-Name" value="OSGi installer test bundle" />
-                                        <attribute name="Bundle-SymbolicName" value="osgi-installer-testbundle" />
-                                        <attribute name="Bundle-Version" value="1.0.4" />
+                                        <attribute name="Manifest-Version" value="2"/>
+                                        <attribute name="Bundle-Name" value="OSGi installer test bundle"/>
+                                        <attribute name="Bundle-SymbolicName" value="osgi-installer-testbundle"/>
+                                        <attribute name="Bundle-Version" value="1.0.4"/>
                                     </manifest>
                                 </jar>
                             </tasks>
                         </configuration>
-					</execution>
-				</executions>
-			</plugin>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -124,8 +130,17 @@
                     </excludePackageNames>
                 </configuration>
             </plugin>
-		</plugins>
-	</build>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>src/test/resources/**</exclude>
+                    </excludes>
+                </configuration>
+             </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <dependency>
@@ -148,39 +163,52 @@
             <version>2.2.0</version>
             <scope>provided</scope>
         </dependency>
-      <!-- We use a class from the config admin implementation to read config files -->
+        <!-- We use a class from the config admin implementation to read config files -->
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.configadmin</artifactId>
             <version>1.8.12</version>
             <scope>provided</scope>
         </dependency>
-      <!--  We use classes from the configurator, json api and converter to read JSON config files -->
+        <!-- We use classes from the configurator, json api and converter to read JSON config files -->
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.configurator</artifactId>
-            <version>1.0.4</version>
+            <version>1.0.10</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.converter</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.8</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.feature.io</artifactId>
+            <version>1.1.1-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <!-- transitive dependency of feature.io -->
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.feature</artifactId>
+            <version>1.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.utils</artifactId>
+            <version>1.11.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
             <artifactId>geronimo-json_1.0_spec</artifactId>
             <version>1.0-alpha-1</version>
-            <scope>provided</scope> 
-        </dependency>
-        <dependency>
-            <groupId>org.apache.johnzon</groupId>
-            <artifactId>johnzon-core</artifactId>
-            <version>1.0.0</version>
             <scope>provided</scope>
         </dependency>
-      <!-- Basic dependencies for Unit Tests -->
+        <!-- Basic dependencies for Unit Tests -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -199,6 +227,18 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>2.13.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.johnzon</groupId>
+            <artifactId>johnzon-core</artifactId>
+            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/apache/sling/installer/api/serializer/ConfigurationSerializer.java
+++ b/src/main/java/org/apache/sling/installer/api/serializer/ConfigurationSerializer.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.installer.api.serializer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Dictionary;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface ConfigurationSerializer {
+    /**
+     * Serializes the given dictionary (usually retrieved from OSGi Config Admin) into a specific format.
+     * Leaves the output stream open.
+     * @param dictionary
+     * @param outputStream
+     * @throws IOException
+     */
+    void serialize(@NotNull Dictionary<String, Object> dictionary, @NotNull OutputStream outputStream) throws IOException;
+}

--- a/src/main/java/org/apache/sling/installer/api/serializer/ConfigurationSerializerFactory.java
+++ b/src/main/java/org/apache/sling/installer/api/serializer/ConfigurationSerializerFactory.java
@@ -29,7 +29,7 @@ public class ConfigurationSerializerFactory {
         CONFIG,
         PROPERTIES,
         PROPERTIES_XML
-    };
+    }
     
     private ConfigurationSerializerFactory() {
     }

--- a/src/main/java/org/apache/sling/installer/api/serializer/ConfigurationSerializerFactory.java
+++ b/src/main/java/org/apache/sling/installer/api/serializer/ConfigurationSerializerFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.installer.api.serializer;
+
+import org.apache.sling.installer.core.impl.ConfigConfigurationSerializer;
+import org.apache.sling.installer.core.impl.JsonConfigurationSerializer;
+import org.apache.sling.installer.core.impl.PropertiesConfigurationSerializer;
+import org.jetbrains.annotations.NotNull;
+
+public class ConfigurationSerializerFactory {
+    public enum Format {
+        JSON,
+        CONFIG,
+        PROPERTIES,
+        PROPERTIES_XML
+    };
+    
+    private ConfigurationSerializerFactory() {
+    }
+
+    public static @NotNull ConfigurationSerializer create(@NotNull Format format) {
+        final ConfigurationSerializer serializer;
+        switch (format) {
+            case CONFIG:
+                serializer = new ConfigConfigurationSerializer();
+                break;
+            case PROPERTIES:
+                serializer = new PropertiesConfigurationSerializer(false);
+                break;
+            case PROPERTIES_XML:
+                serializer = new PropertiesConfigurationSerializer(true);
+                break;
+            default:
+                serializer = new JsonConfigurationSerializer();
+                break;
+        }
+        return serializer;
+    }
+}

--- a/src/main/java/org/apache/sling/installer/api/serializer/package-info.java
+++ b/src/main/java/org/apache/sling/installer/api/serializer/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+@org.osgi.annotation.versioning.Version("1.0.0")
+package org.apache.sling.installer.api.serializer;

--- a/src/main/java/org/apache/sling/installer/core/impl/ConfigConfigurationSerializer.java
+++ b/src/main/java/org/apache/sling/installer/core/impl/ConfigConfigurationSerializer.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.installer.core.impl;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Dictionary;
+
+import org.apache.felix.cm.file.ConfigurationHandler;
+import org.apache.sling.installer.api.serializer.ConfigurationSerializer;
+import org.jetbrains.annotations.NotNull;
+
+public class ConfigConfigurationSerializer implements ConfigurationSerializer {
+
+    @Override
+    public void serialize(@NotNull Dictionary<String, Object> dictionary, @NotNull OutputStream outputStream) throws IOException {
+        ConfigurationHandler.write(outputStream, dictionary);
+    }
+}

--- a/src/main/java/org/apache/sling/installer/core/impl/JsonConfigurationSerializer.java
+++ b/src/main/java/org/apache/sling/installer/core/impl/JsonConfigurationSerializer.java
@@ -25,7 +25,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.Dictionary;
 
-import org.apache.sling.feature.io.json.ConfigurationJSONWriter;
+import org.apache.sling.feature.io.ConfiguratorUtil;
 import org.apache.sling.installer.api.serializer.ConfigurationSerializer;
 
 /** Serializes dictionary configuration objects (as specified in the configuration admin) into JSON format.
@@ -38,7 +38,7 @@ public class JsonConfigurationSerializer implements ConfigurationSerializer {
     @Override
     public void serialize(Dictionary<String, Object> dictionary, OutputStream outputStream) throws IOException {
         Writer writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
-        ConfigurationJSONWriter.writeConfiguration(writer, dictionary);
+        ConfiguratorUtil.writeConfiguration(writer, dictionary);
         writer.flush();
         // do not close the writer to prevent closing the underlying outputstream
     }

--- a/src/main/java/org/apache/sling/installer/core/impl/JsonConfigurationSerializer.java
+++ b/src/main/java/org/apache/sling/installer/core/impl/JsonConfigurationSerializer.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.installer.core.impl;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.Dictionary;
+
+import org.apache.sling.feature.io.json.ConfigurationJSONWriter;
+import org.apache.sling.installer.api.serializer.ConfigurationSerializer;
+
+/** Serializes dictionary configuration objects (as specified in the configuration admin) into JSON format.
+ * 
+ * @see <a href="https://osgi.org/specification/osgi.cmpn/7.0.0/service.configurator.html">OSGi Configurator Spec</a>
+ * @see <a href=
+ *      "https://github.com/apache/felix/blob/trunk/configurator/src/main/java/org/apache/felix/configurator/impl/json/JSONUtil.java">JSONUtil</a> */
+public class JsonConfigurationSerializer implements ConfigurationSerializer {
+
+    @Override
+    public void serialize(Dictionary<String, Object> dictionary, OutputStream outputStream) throws IOException {
+        Writer writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
+        ConfigurationJSONWriter.writeConfiguration(writer, dictionary);
+        writer.flush();
+        // do not close the writer to prevent closing the underlying outputstream
+    }
+}

--- a/src/main/java/org/apache/sling/installer/core/impl/PropertiesConfigurationSerializer.java
+++ b/src/main/java/org/apache/sling/installer/core/impl/PropertiesConfigurationSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.installer.core.impl;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Dictionary;
+import java.util.Properties;
+
+import org.apache.sling.installer.api.serializer.ConfigurationSerializer;
+import org.jetbrains.annotations.NotNull;
+import org.osgi.util.converter.Converter;
+import org.osgi.util.converter.Converters;
+
+public class PropertiesConfigurationSerializer implements ConfigurationSerializer {
+
+    private final boolean isXml;
+    
+    public PropertiesConfigurationSerializer(boolean isXml) {
+        this.isXml = isXml;
+    }
+
+    @Override
+    public void serialize(@NotNull Dictionary<String, Object> dictionary, @NotNull OutputStream outputStream) throws IOException {
+        // convert to properties object
+        Converter converter = Converters.standardConverter();
+        Properties properties = converter.convert(dictionary).to(Properties.class);
+        if (!isXml) {
+            properties.store(outputStream, null);
+        } else {
+            properties.storeToXML(outputStream, null);
+        }
+    }
+
+}

--- a/src/test/java/org/apache/sling/installer/api/serializer/ConfigurationSerializerTest.java
+++ b/src/test/java/org/apache/sling/installer/api/serializer/ConfigurationSerializerTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.installer.api.serializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.LineIterator;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class ConfigurationSerializerTest {
+
+    @Parameters(name = "Serializer:{0}")
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { ConfigurationSerializerFactory.Format.JSON, "config1.json" },
+                { ConfigurationSerializerFactory.Format.CONFIG, "config1.config" },
+                { ConfigurationSerializerFactory.Format.PROPERTIES, "config1.cfg" },
+                { ConfigurationSerializerFactory.Format.PROPERTIES_XML, "config1.xml" }
+        });
+    }
+
+    private final ConfigurationSerializer serializer;
+    private final LineIterator lineIterator;
+
+    public ConfigurationSerializerTest(ConfigurationSerializerFactory.Format format, String resource) throws IOException {
+        this.serializer = ConfigurationSerializerFactory.create(format);
+        InputStream input = this.getClass().getResourceAsStream(resource);
+        lineIterator = IOUtils.lineIterator(input, StandardCharsets.UTF_8);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        lineIterator.close();
+    }
+
+    @Test
+    public void testSerializer() throws IOException {
+        Dictionary<String, Object> dictionary = new Hashtable<>();
+
+        dictionary.put("String-value", "test");
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        serializer.serialize(dictionary, output);
+        output.close();
+
+        try (ByteArrayInputStream input = new ByteArrayInputStream(output.toByteArray())) {
+            LineIterator actualLineIterator = IOUtils.lineIterator(input, StandardCharsets.UTF_8);
+            // compare line by line
+            while (lineIterator.hasNext()) {
+                String expectedLine = lineIterator.nextLine();
+                String actualLine = actualLineIterator.nextLine();
+                // ignore lines starting with "*"
+                if (!expectedLine.equals("*")) {
+                    Assert.assertEquals(expectedLine, actualLine);
+                }
+            }
+        }
+    }
+}

--- a/src/test/resources/org/apache/sling/installer/api/serializer/config1.cfg
+++ b/src/test/resources/org/apache/sling/installer/api/serializer/config1.cfg
@@ -1,0 +1,2 @@
+*
+String-value=test

--- a/src/test/resources/org/apache/sling/installer/api/serializer/config1.config
+++ b/src/test/resources/org/apache/sling/installer/api/serializer/config1.config
@@ -1,0 +1,1 @@
+String-value="test"

--- a/src/test/resources/org/apache/sling/installer/api/serializer/config1.json
+++ b/src/test/resources/org/apache/sling/installer/api/serializer/config1.json
@@ -1,0 +1,3 @@
+{
+  "String-value":"test"
+}

--- a/src/test/resources/org/apache/sling/installer/api/serializer/config1.xml
+++ b/src/test/resources/org/apache/sling/installer/api/serializer/config1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+<properties>
+<entry key="String-value">test</entry>
+</properties>


### PR DESCRIPTION
Config serializers are now part of installer core so that all providers
can just use them.