### PR TITLE
upgrade m-shade-p for Reproducible Builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <id>shade-embedded</id>


### PR DESCRIPTION
using 3.2.2 gives unreproducible output https://github.com/jvm-repo-rebuild/reproducible-central#org.apache.sling:org.apache.sling.installer.core

3.2.3 is the first release producing reproducible output