### PR TITLE
SLING-12843: Sling Installer core ignores startlevel change of bundles

### DIFF
--- a/src/main/java/org/apache/sling/installer/core/impl/tasks/BundleTaskCreator.java
+++ b/src/main/java/org/apache/sling/installer/core/impl/tasks/BundleTaskCreator.java
@@ -37,6 +37,7 @@ import org.apache.sling.installer.core.impl.OsgiInstallerImpl;
 import org.apache.sling.installer.core.impl.PersistentResourceList;
 import org.apache.sling.installer.core.impl.RegisteredResourceImpl;
 import org.apache.sling.installer.core.impl.Util;
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleEvent;
 import org.osgi.framework.BundleListener;
@@ -44,6 +45,7 @@ import org.osgi.framework.Constants;
 import org.osgi.framework.FrameworkEvent;
 import org.osgi.framework.FrameworkListener;
 import org.osgi.framework.Version;
+import org.osgi.framework.startlevel.BundleStartLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -259,6 +261,8 @@ public class BundleTaskCreator implements InternalService, InstallTaskFactory, F
                     }
 
                     final BundleInfo info = this.getBundleInfo(symbolicName, bundleVersion);
+                    final int currentStartLevel = getCurrentBundleStartLevel(info);
+                    final int newStartLevel = getNewBundleStartLevel(toActivate);
 
                     // check if we should start the bundle as we installed it in the previous run
                     if (info == null) {
@@ -281,7 +285,8 @@ public class BundleTaskCreator implements InternalService, InstallTaskFactory, F
                                 logger.debug("Bundle " + info.symbolicName + " " + newVersion
                                         + " is not installed, bundle with higher version is already installed.");
                             }
-                        } else if (compare == 0 && BundleInfo.isSnapshot(newVersion)) {
+                        } else if (compare == 0
+                                && (BundleInfo.isSnapshot(newVersion) || currentStartLevel != newStartLevel)) {
 
                             // installed, same version but SNAPSHOT
                             doUpdate = true;
@@ -323,5 +328,54 @@ public class BundleTaskCreator implements InternalService, InstallTaskFactory, F
 
     protected BundleInfo getBundleInfo(final String symbolicName, final String version) {
         return BundleInfo.getBundleInfo(this.bundleContext, symbolicName, version);
+    }
+
+    /**
+     * Gets the current start level of a bundle.
+     *
+     * @param info the bundle info, may be null if bundle is not installed
+     * @return the current start level, or 0 if not available
+     */
+    protected int getCurrentBundleStartLevel(final BundleInfo info) {
+        final int FALLBACK_START_LEVEL = 0;
+        if (info == null) {
+            return FALLBACK_START_LEVEL;
+        }
+
+        final Bundle currentBundle = this.bundleContext.getBundle(info.id);
+        if (currentBundle == null) {
+            return FALLBACK_START_LEVEL;
+        }
+
+        final BundleStartLevel bundleStartLevel = currentBundle.adapt(BundleStartLevel.class);
+        if (bundleStartLevel == null) {
+            return FALLBACK_START_LEVEL;
+        }
+
+        return bundleStartLevel.getStartLevel();
+    }
+
+    /**
+     * Gets the new start level for a bundle from the installation hint.
+     *
+     * @param toActivate the task resource containing installation hints
+     * @return the new start level
+     */
+    protected int getNewBundleStartLevel(final TaskResource toActivate) {
+        final int FALLBACK_START_LEVEL = 0;
+        if (toActivate == null) {
+            return FALLBACK_START_LEVEL;
+        }
+        final Object installationHint = toActivate.getDictionary().get(InstallableResource.INSTALLATION_HINT);
+        if (installationHint == null) {
+            return FALLBACK_START_LEVEL;
+        }
+
+        try {
+            return Integer.parseInt(installationHint.toString());
+        } catch (NumberFormatException e) {
+            logger.warn("Invalid installation hint value '{}' for bundle {}", installationHint, toActivate.getURL());
+            return FALLBACK_START_LEVEL;
+        }
     }
 }

--- a/src/main/java/org/apache/sling/installer/core/impl/tasks/BundleTaskCreator.java
+++ b/src/main/java/org/apache/sling/installer/core/impl/tasks/BundleTaskCreator.java
@@ -336,7 +336,7 @@ public class BundleTaskCreator implements InternalService, InstallTaskFactory, F
      * @param info the bundle info, may be null if bundle is not installed
      * @return the current start level, or 0 if not available
      */
-    protected int getCurrentBundleStartLevel(final BundleInfo info) {
+    private int getCurrentBundleStartLevel(final BundleInfo info) {
         final int FALLBACK_START_LEVEL = 0;
         if (info == null) {
             return FALLBACK_START_LEVEL;
@@ -361,11 +361,8 @@ public class BundleTaskCreator implements InternalService, InstallTaskFactory, F
      * @param toActivate the task resource containing installation hints
      * @return the new start level
      */
-    protected int getNewBundleStartLevel(final TaskResource toActivate) {
+    private int getNewBundleStartLevel(final TaskResource toActivate) {
         final int FALLBACK_START_LEVEL = 0;
-        if (toActivate == null) {
-            return FALLBACK_START_LEVEL;
-        }
         final Object installationHint = toActivate.getDictionary().get(InstallableResource.INSTALLATION_HINT);
         if (installationHint == null) {
             return FALLBACK_START_LEVEL;

--- a/src/main/java/org/apache/sling/installer/core/impl/tasks/BundleUpdateTask.java
+++ b/src/main/java/org/apache/sling/installer/core/impl/tasks/BundleUpdateTask.java
@@ -79,7 +79,10 @@ public class BundleUpdateTask extends AbstractBundleTask {
         boolean snapshot = false;
         final Version currentVersion = b.getVersion();
         snapshot = BundleInfo.isSnapshot(newVersion);
-        if (currentVersion.equals(newVersion) && !snapshot) {
+        final BundleStartLevel startLevelService = b.adapt(BundleStartLevel.class);
+        final int newStartLevel = this.getBundleStartLevel();
+        final int oldStartLevel = startLevelService.getStartLevel();
+        if (currentVersion.equals(newVersion) && !snapshot && newStartLevel == oldStartLevel) {
             // TODO : Isn't this already checked in the task creator?
             String message = MessageFormat.format(
                     "Same version is already installed, and not a snapshot, ignoring update: {0}", getResource());
@@ -105,9 +108,6 @@ public class BundleUpdateTask extends AbstractBundleTask {
             setBundleLocation(getResource(), b.getLocation());
             // start level handling - after update to avoid starting the bundle
             // just before the update
-            final BundleStartLevel startLevelService = b.adapt(BundleStartLevel.class);
-            final int newStartLevel = this.getBundleStartLevel();
-            final int oldStartLevel = startLevelService.getStartLevel();
             if (newStartLevel != oldStartLevel && newStartLevel != 0) {
                 startLevelService.setStartLevel(newStartLevel);
                 ctx.log("Set start level for bundle {} to {}", b, newStartLevel);

--- a/src/test/java/org/apache/sling/installer/core/impl/MockBundleContext.java
+++ b/src/test/java/org/apache/sling/installer/core/impl/MockBundleContext.java
@@ -22,9 +22,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Dictionary;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Map;
 
 import org.osgi.framework.Bundle;
@@ -42,6 +44,18 @@ import org.osgi.framework.ServiceRegistration;
 import org.osgi.framework.Version;
 
 public class MockBundleContext implements BundleContext {
+
+    private final List<Bundle> bundles = new ArrayList<>();
+
+    public MockBundleContext() {
+        // Default constructor
+    }
+
+    public MockBundleContext(final List<Bundle> bundleList) {
+        if (bundleList != null) {
+            this.bundles.addAll(bundleList);
+        }
+    }
 
     @Override
     public boolean ungetService(ServiceReference reference) {
@@ -134,13 +148,16 @@ public class MockBundleContext implements BundleContext {
 
     @Override
     public Bundle[] getBundles() {
-        // TODO Auto-generated method stub
-        return null;
+        return this.bundles.toArray(new Bundle[0]);
     }
 
     @Override
     public Bundle getBundle(long id) {
-        // TODO Auto-generated method stub
+        for (Bundle bundle : this.bundles) {
+            if (bundle.getBundleId() == id) {
+                return bundle;
+            }
+        }
         return null;
     }
 

--- a/src/test/java/org/apache/sling/installer/core/impl/MockBundleResource.java
+++ b/src/test/java/org/apache/sling/installer/core/impl/MockBundleResource.java
@@ -21,6 +21,7 @@ package org.apache.sling.installer.core.impl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Dictionary;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Map;
@@ -44,6 +45,7 @@ public class MockBundleResource implements TaskResource, Comparable<MockBundleRe
     private ResourceState state = ResourceState.INSTALL;
     private final String digest;
     private final int priority;
+    private final Dictionary<String, Object> dictionary = new Hashtable<>();
 
     public MockBundleResource(String symbolicName, String version) {
         this(symbolicName, version, InstallableResource.DEFAULT_PRIORITY);
@@ -61,6 +63,15 @@ public class MockBundleResource implements TaskResource, Comparable<MockBundleRe
         attributes.put(Constants.BUNDLE_VERSION, version);
         this.digest = digest;
         this.priority = priority;
+    }
+
+    public void setDictionary(Dictionary<String, Object> dictionary) {
+        Enumeration<String> keys = dictionary.keys();
+        while (keys.hasMoreElements()) {
+            String key = keys.nextElement();
+            Object value = dictionary.get(key);
+            this.dictionary.put(key, value);
+        }
     }
 
     @Override
@@ -83,7 +94,7 @@ public class MockBundleResource implements TaskResource, Comparable<MockBundleRe
      * @see org.apache.sling.installer.api.tasks.RegisteredResource#getDictionary()
      */
     public Dictionary<String, Object> getDictionary() {
-        return null;
+        return dictionary;
     }
 
     /**
@@ -211,7 +222,7 @@ public class MockBundleResource implements TaskResource, Comparable<MockBundleRe
         final InstallableResource is = new InstallableResource(
                 (String) this.attributes.get(Constants.BUNDLE_SYMBOLICNAME),
                 null,
-                new Hashtable<String, Object>(),
+                getDictionary(),
                 this.getDigest(),
                 this.getType(),
                 this.getPriority());

--- a/src/test/java/org/apache/sling/installer/core/impl/tasks/BundleTaskCreatorTest.java
+++ b/src/test/java/org/apache/sling/installer/core/impl/tasks/BundleTaskCreatorTest.java
@@ -142,6 +142,19 @@ public class BundleTaskCreatorTest {
     }
 
     @Test
+    public void testBundleUpgradeStartLevelChanged() throws IOException {
+        final TaskResource[] r = {new MockBundleResource(SN, "1.1")};
+
+        {
+            final MockBundleTaskCreator c = new MockBundleTaskCreator(20, 19);
+            c.addBundleInfo(SN, "1.1", Bundle.ACTIVE);
+            final SortedSet<InstallTask> s = getTasks(r, c);
+            assertEquals("Expected one task", 1, s.size());
+            assertTrue("Expected a BundleUpdateTask", s.first() instanceof BundleUpdateTask);
+        }
+    }
+
+    @Test
     public void testBundleRemoveSingle() throws IOException {
         final String version = "1.0";
         final MockBundleResource[] r = {new MockBundleResource(SN, version)};

--- a/src/test/java/org/apache/sling/installer/core/impl/tasks/BundleTaskCreatorTest.java
+++ b/src/test/java/org/apache/sling/installer/core/impl/tasks/BundleTaskCreatorTest.java
@@ -18,12 +18,14 @@
  */
 package org.apache.sling.installer.core.impl.tasks;
 
-import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.security.cert.X509Certificate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.apache.sling.installer.api.InstallableResource;
 import org.apache.sling.installer.api.tasks.ChangeStateTask;
@@ -32,17 +34,15 @@ import org.apache.sling.installer.api.tasks.ResourceState;
 import org.apache.sling.installer.api.tasks.TaskResource;
 import org.apache.sling.installer.core.impl.EntityResourceList;
 import org.apache.sling.installer.core.impl.MockBundleResource;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.BundleException;
-import org.osgi.framework.ServiceReference;
 import org.osgi.framework.startlevel.BundleStartLevel;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 public class BundleTaskCreatorTest {
     public static final String SN = "TestSymbolicName";
@@ -408,166 +408,16 @@ public class BundleTaskCreatorTest {
     }
 
     private Bundle getMockBundle(long bundleId, String symbolicName, Integer startLevel) {
-        return new Bundle() {
-            @Override
-            public int getState() {
-                return 0;
-            }
-
-            @Override
-            public void start(int i) throws BundleException {}
-
-            @Override
-            public void start() throws BundleException {}
-
-            @Override
-            public void stop(int i) throws BundleException {}
-
-            @Override
-            public void stop() throws BundleException {}
-
-            @Override
-            public void update(InputStream inputStream) throws BundleException {}
-
-            @Override
-            public void update() throws BundleException {}
-
-            @Override
-            public void uninstall() throws BundleException {}
-
-            @Override
-            public Dictionary<String, String> getHeaders() {
-                return null;
-            }
-
-            @Override
-            public long getBundleId() {
-                return bundleId;
-            }
-
-            @Override
-            public String getLocation() {
-                return "";
-            }
-
-            @Override
-            public ServiceReference<?>[] getRegisteredServices() {
-                return new ServiceReference[0];
-            }
-
-            @Override
-            public ServiceReference<?>[] getServicesInUse() {
-                return new ServiceReference[0];
-            }
-
-            @Override
-            public boolean hasPermission(Object o) {
-                return false;
-            }
-
-            @Override
-            public URL getResource(String s) {
-                return null;
-            }
-
-            @Override
-            public Dictionary<String, String> getHeaders(String s) {
-                return null;
-            }
-
-            @Override
-            public String getSymbolicName() {
-                return symbolicName;
-            }
-
-            @Override
-            public Class<?> loadClass(String s) throws ClassNotFoundException {
-                return null;
-            }
-
-            @Override
-            public Enumeration<URL> getResources(String s) throws IOException {
-                return null;
-            }
-
-            @Override
-            public Enumeration<String> getEntryPaths(String s) {
-                return null;
-            }
-
-            @Override
-            public URL getEntry(String s) {
-                return null;
-            }
-
-            @Override
-            public long getLastModified() {
-                return 0;
-            }
-
-            @Override
-            public Enumeration<URL> findEntries(String s, String s1, boolean b) {
-                return null;
-            }
-
-            @Override
-            public BundleContext getBundleContext() {
-                return null;
-            }
-
-            @Override
-            public Map<X509Certificate, List<X509Certificate>> getSignerCertificates(int i) {
-                return null;
-            }
-
-            @Override
-            public org.osgi.framework.Version getVersion() {
-                return null;
-            }
-
-            @Override
-            public <A> A adapt(Class<A> aClass) {
-                if (startLevel == null) {
-                    return null;
-                }
-                if (aClass == BundleStartLevel.class) {
-                    return aClass.cast(new BundleStartLevel() {
-                        @Override
-                        public Bundle getBundle() {
-                            return null;
-                        }
-
-                        @Override
-                        public int getStartLevel() {
-                            return startLevel;
-                        }
-
-                        @Override
-                        public void setStartLevel(int i) {}
-
-                        @Override
-                        public boolean isPersistentlyStarted() {
-                            return false;
-                        }
-
-                        @Override
-                        public boolean isActivationPolicyUsed() {
-                            return false;
-                        }
-                    });
-                }
-                return null;
-            }
-
-            @Override
-            public File getDataFile(String s) {
-                return null;
-            }
-
-            @Override
-            public int compareTo(@NotNull Bundle o) {
-                return 0;
-            }
-        };
+        // Create a mock bundle with the specified symbolic name and start level
+        Bundle bundle = Mockito.mock(Bundle.class);
+        when(bundle.getSymbolicName()).thenReturn(symbolicName);
+        when(bundle.getBundleId()).thenReturn(bundleId);
+        when(bundle.getState()).thenReturn(Bundle.ACTIVE);
+        if (startLevel != null) {
+            BundleStartLevel bundleStartLevel = Mockito.mock(BundleStartLevel.class);
+            when(bundleStartLevel.getStartLevel()).thenReturn(startLevel);
+            when(bundle.adapt(BundleStartLevel.class)).thenReturn(bundleStartLevel);
+        }
+        return bundle;
     }
 }

--- a/src/test/java/org/apache/sling/installer/core/impl/tasks/BundleUpdateTaskTest.java
+++ b/src/test/java/org/apache/sling/installer/core/impl/tasks/BundleUpdateTaskTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.installer.core.impl.tasks;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.sling.installer.api.tasks.InstallationContext;
+import org.apache.sling.installer.api.tasks.ResourceState;
+import org.apache.sling.installer.core.impl.EntityResourceList;
+import org.apache.sling.installer.core.impl.MockBundleResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Version;
+import org.osgi.framework.startlevel.BundleStartLevel;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BundleUpdateTaskTest {
+
+    private static final String BUNDLE_SYMBOLIC_NAME = "test.bundle";
+    private static final String BUNDLE_VERSION = "1.1.0";
+
+    @Mock
+    private BundleContext bundleContext;
+
+    @Mock
+    private Bundle bundle;
+
+    @Mock
+    private BundleStartLevel bundleStartLevel;
+
+    @Mock
+    private InstallationContext installationContext;
+
+    @Mock
+    private TaskSupport taskSupport;
+
+    @Test
+    public void testBundleUpdateExecute_BundleNotFound() throws Exception {
+        List<Bundle> bundles = new ArrayList<>();
+        bundles.add(bundle);
+        // Setup bundle context
+        when(bundleContext.getBundles()).thenReturn(bundles.toArray(new Bundle[0]));
+        // Setup task support
+        when(taskSupport.getBundleContext()).thenReturn(bundleContext);
+        // Setup resource with proper InputStream
+        MockBundleResource resource = new MockBundleResource(BUNDLE_SYMBOLIC_NAME, BUNDLE_VERSION) {
+            @Override
+            public InputStream getInputStream() throws IOException {
+                return new ByteArrayInputStream("test bundle content".getBytes());
+            }
+        };
+        EntityResourceList resourceList =
+                new EntityResourceList(resource.getEntityId(), new MockInstallationListener());
+        try {
+            resourceList.addOrUpdate(resource.getRegisteredResourceImpl());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Create task
+        BundleUpdateTask task = new BundleUpdateTask(resourceList, taskSupport);
+        // Given: Bundle not found in context
+        when(bundleContext.getBundles()).thenReturn(new Bundle[0]);
+
+        // When: Execute task
+        task.execute(installationContext);
+
+        // Then: Task should be ignored
+        assertEquals(ResourceState.IGNORED, resourceList.getFirstResource().getState());
+        assertTrue(resourceList
+                .getFirstResource()
+                .getError()
+                .contains("Bundle to update (" + BUNDLE_SYMBOLIC_NAME + ") not found"));
+    }
+
+    @Test
+    public void testBundleUpdateExecute_SameVersionNonSnapshotSameStartLevel() throws Exception {
+        List<Bundle> bundles = new ArrayList<>();
+        // Setup basic bundle mock
+        when(bundle.getSymbolicName()).thenReturn(BUNDLE_SYMBOLIC_NAME);
+        when(bundle.getVersion()).thenReturn(new Version(BUNDLE_VERSION));
+        when(bundle.adapt(BundleStartLevel.class)).thenReturn(bundleStartLevel);
+        bundles.add(bundle);
+        // Setup bundle context
+        when(bundleContext.getBundles()).thenReturn(bundles.toArray(new Bundle[0]));
+        // Setup task support
+        when(taskSupport.getBundleContext()).thenReturn(bundleContext);
+        // Setup resource with proper InputStream
+        MockBundleResource resource = new MockBundleResource(BUNDLE_SYMBOLIC_NAME, BUNDLE_VERSION) {
+            @Override
+            public InputStream getInputStream() throws IOException {
+                return new ByteArrayInputStream("test bundle content".getBytes());
+            }
+        };
+        EntityResourceList resourceList =
+                new EntityResourceList(resource.getEntityId(), new MockInstallationListener());
+        try {
+            resourceList.addOrUpdate(resource.getRegisteredResourceImpl());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Create task
+        BundleUpdateTask task = new BundleUpdateTask(resourceList, taskSupport);
+
+        // When: Execute task
+        task.execute(installationContext);
+
+        assertEquals(ResourceState.INSTALLED, resourceList.getFirstResource().getState());
+        assertTrue(resourceList
+                .getFirstResource()
+                .getError()
+                .contains("Same version is already installed, and not a snapshot, ignoring update"));
+    }
+}

--- a/src/test/java/org/apache/sling/installer/core/impl/tasks/MockBundleTaskCreator.java
+++ b/src/test/java/org/apache/sling/installer/core/impl/tasks/MockBundleTaskCreator.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.sling.installer.api.tasks.TaskResource;
 import org.apache.sling.installer.core.impl.MockBundleContext;
 import org.osgi.framework.Version;
 
@@ -29,13 +30,31 @@ import org.osgi.framework.Version;
 class MockBundleTaskCreator extends BundleTaskCreator {
 
     private final Map<String, BundleInfo> fakeBundleInfo = new HashMap<String, BundleInfo>();
+    private final int currentStartLevel;
+    private final int newStartLevel;
 
     public MockBundleTaskCreator() throws IOException {
+        this(20, 20);
+    }
+
+    public MockBundleTaskCreator(int currentStartLevel, int newStartLevel) {
         this.init(new MockBundleContext(), null, null);
+        this.currentStartLevel = currentStartLevel;
+        this.newStartLevel = newStartLevel;
     }
 
     void addBundleInfo(String symbolicName, String version, int state) {
         fakeBundleInfo.put(symbolicName, new BundleInfo(symbolicName, new Version(version), state, 1));
+    }
+
+    @Override
+    protected int getNewBundleStartLevel(final TaskResource toActivate) {
+        return newStartLevel;
+    }
+
+    @Override
+    protected int getCurrentBundleStartLevel(final BundleInfo info) {
+        return currentStartLevel;
     }
 
     @Override

--- a/src/test/java/org/apache/sling/installer/core/impl/tasks/MockBundleTaskCreator.java
+++ b/src/test/java/org/apache/sling/installer/core/impl/tasks/MockBundleTaskCreator.java
@@ -18,43 +18,29 @@
  */
 package org.apache.sling.installer.core.impl.tasks;
 
-import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-import org.apache.sling.installer.api.tasks.TaskResource;
 import org.apache.sling.installer.core.impl.MockBundleContext;
+import org.osgi.framework.Bundle;
 import org.osgi.framework.Version;
 
 /** BundleTaskCreator that simulates the presence and state of bundles */
 class MockBundleTaskCreator extends BundleTaskCreator {
 
     private final Map<String, BundleInfo> fakeBundleInfo = new HashMap<String, BundleInfo>();
-    private final int currentStartLevel;
-    private final int newStartLevel;
 
-    public MockBundleTaskCreator() throws IOException {
-        this(20, 20);
+    public MockBundleTaskCreator() {
+        this.init(new MockBundleContext(), null, null);
     }
 
-    public MockBundleTaskCreator(int currentStartLevel, int newStartLevel) {
-        this.init(new MockBundleContext(), null, null);
-        this.currentStartLevel = currentStartLevel;
-        this.newStartLevel = newStartLevel;
+    public MockBundleTaskCreator(final List<Bundle> bundles) {
+        this.init(new MockBundleContext(bundles), null, null);
     }
 
     void addBundleInfo(String symbolicName, String version, int state) {
         fakeBundleInfo.put(symbolicName, new BundleInfo(symbolicName, new Version(version), state, 1));
-    }
-
-    @Override
-    protected int getNewBundleStartLevel(final TaskResource toActivate) {
-        return newStartLevel;
-    }
-
-    @Override
-    protected int getCurrentBundleStartLevel(final BundleInfo info) {
-        return currentStartLevel;
     }
 
     @Override


### PR DESCRIPTION
This PR enhances the bundle installation logic to also consider the start level, ensuring that bundles with different start levels are not ignored during installation, even if their version match.